### PR TITLE
Pause Ghosting (+ prevent unloading when unpacked)

### DIFF
--- a/KISSMultiplayer/lua/ge/extensions/kissmods.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kissmods.lua
@@ -49,7 +49,7 @@ local function deactivate_all_mods()
     FS:unmount(mod_path)
   end
   for k, mod_path in pairs(FS:directoryList("/mods/unpacked/", "*", 1)) do
-    if not is_app_mod(mod_path) then
+    if not mod_path:match("KISSMultiplayer") and not is_app_mod(mod_path) then
       FS:unmount(mod_path.."/")
     end
   end

--- a/KISSMultiplayer/lua/ge/extensions/kisstransform.lua
+++ b/KISSMultiplayer/lua/ge/extensions/kisstransform.lua
@@ -14,6 +14,7 @@ M.rot_threshold = 2.5
 M.velocity_error_limit = 10
 
 M.hidden = {}
+M.paused = {}
 
 local function update(dt)
   if not network.connection.connected then return end
@@ -57,11 +58,17 @@ local function update_vehicle_transform(data)
   local id = vehiclemanager.id_map[transform.owner or -1] or -1
   if vehiclemanager.ownership[id] then return end
   M.raw_positions[transform.owner or -1] = transform.position
-  M.received_transforms[id] = transform
 
   local vehicle = be:getObjectByID(id)
   if vehicle and (not M.inactive[id]) then
     transform.time_past = clamp(vehiclemanager.get_current_time() - transform.sent_at, 0, 0.1) * 0.9 + 0.001
+    if M.paused[id] then
+      vehicle:applyClusterVelocityScaleAdd(0, 0.25, 0.25, 0.25, 0, 0, 0)
+      local target_position = vec3(transform.position)
+
+      vehicle:setPositionNoPhysicsReset(target_position)
+    end
+    M.received_transforms[id] = transform
     vehicle:queueLuaCommand("kiss_transforms.set_target_transform(\'"..jsonEncode(transform).."\')")
   end
 end
@@ -70,10 +77,20 @@ local function push_transform(id, t)
   M.local_transforms[id] = jsonDecode(t)
 end
 
+local function set_paused(id, paused)
+  M.paused[id] = paused
+  local vehicle = be:getObjectByID(id)
+  if vehicle then
+    vehicle:setMeshAlpha(paused and 0.5 or 1, "")
+    vehicle:queueLuaCommand("kiss_vehicle.set_paused("..tostring(paused)..")")
+  end
+end
+
 M.send_transform_updates = send_transform_updates
 M.send_vehicle_transform = send_vehicle_transform
 M.update_vehicle_transform = update_vehicle_transform
 M.push_transform = push_transform
+M.set_paused = set_paused
 M.onUpdate = update
 
 return M

--- a/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
+++ b/KISSMultiplayer/lua/ge/extensions/vehiclemanager.lua
@@ -8,6 +8,7 @@ local meta_timer = 0
 local colors_buffer = {}
 local plates_buffer = {}
 local first_vehicle = true
+local slowmo_factor = 0
 
 M.loading_map = false
 M.id_map = {}
@@ -121,7 +122,8 @@ local function send_vehicle_meta_updates()
           VehicleMetaUpdate = {
             id,
             plate,
-            colors
+            colors,
+            slowmo_factor
           }
         }
         network.send_data(data, true)
@@ -174,6 +176,7 @@ local function send_vehicle_config_inner(id, parts_config, data)
   vehicle_data.rotation = {rotation.x, rotation.y, rotation.z, rotation.w}
   vehicle_data.server_id = 0
   vehicle_data.owner = 0
+  vehicle_data.slowmo_factor = bullettime.get()
   network.send_data(
     {
       VehicleData = vehicle_data
@@ -261,8 +264,10 @@ local function onUpdate(dt)
     network.disconnect()
   end
   -- Track color and plate changes
+  local new_slowmo_factor = bullettime.get()
   meta_timer = meta_timer + dt
-  if meta_timer >= 1 then
+  if meta_timer >= 1 or new_slowmo_factor ~= slowmo_factor then
+    slowmo_factor = new_slowmo_factor
     send_vehicle_meta_updates()
     meta_timer = meta_timer - 1
   end
@@ -383,6 +388,7 @@ local function update_vehicle_meta(data)
   local vehicle = be:getObjectByID(id)
   if not vehicle then return end
   local plate = data.plate
+  local slowmo_factor = data.slowmo_factor
   
   local color = data.colors_table[1]
   local palete_0 = data.colors_table[2]
@@ -407,6 +413,9 @@ local function update_vehicle_meta(data)
     extensions.core_vehicle_manager.liveUpdateVehicleColors(id, vehicle, i, table_to_color(ct))
   end
   vehicle:setField('partConfig', '', serialize(vd.config))
+  
+  -- Apply pause
+  kisstransform.set_paused(id, slowmo_factor == 0)
 end
 
 local function electrics_diff_update(data)

--- a/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_vehicle.lua
+++ b/KISSMultiplayer/lua/vehicle/extensions/kiss_mp/kiss_vehicle.lua
@@ -3,6 +3,8 @@ local parts_config = v.config
 local nodes = {}
 local ref_nodes = {}
 
+M.is_paused = false
+
 local last_node = 1
 local nodes_per_frame = 32
 
@@ -144,11 +146,17 @@ local function send_vehicle_config()
   obj:queueGameEngineLua("vehiclemanager.send_vehicle_config_inner("..obj:getID()..", \'"..jsonEncode(config).."\', \'"..jsonEncode(data).."\')")
 end
 
+local function set_paused(bool)
+  M.is_paused = bool
+  obj:setGhostEnabled(M.is_paused)
+end
+
 M.update_transform_info = update_transform_info
 M.apply_linear_velocity_ang_torque = apply_linear_velocity_ang_torque
 M.update_eligible_nodes = update_eligible_nodes
 M.apply_linear_velocity = apply_linear_velocity
 M.onExtensionLoaded = onExtensionLoaded
+M.set_paused = set_paused
 M.set_reference = set_reference
 M.save_state = save_state
 M.send_vehicle_config = send_vehicle_config

--- a/kissmp-server/src/events.rs
+++ b/kissmp-server/src/events.rs
@@ -192,6 +192,7 @@ impl Server {
                                 vehicle.data.palete_0 = meta.colors_table[1];
                                 vehicle.data.palete_1 = meta.colors_table[2];
                                 vehicle.data.plate = meta.plate.clone();
+                                vehicle.data.slowmo_factor = meta.slowmo_factor.clone();
                                 let mut meta = meta.clone();
                                 meta.vehicle_id = server_id;
                                 for (_, client) in &mut self.connections {

--- a/kissmp-server/src/lua.rs
+++ b/kissmp-server/src/lua.rs
@@ -426,7 +426,7 @@ pub fn setup_lua() -> (rlua::Lua, mpsc::Receiver<LuaCommand>) {
         let build_vehicle = lua_ctx
             .create_function(
                 move |_,
-                      (parts_config, color, p0, p1, plate, name, position, rotation): (
+                      (parts_config, color, p0, p1, plate, name, position, rotation, slowmo_factor): (
                     String,
                     Vec<f32>,
                     Vec<f32>,
@@ -435,6 +435,7 @@ pub fn setup_lua() -> (rlua::Lua, mpsc::Receiver<LuaCommand>) {
                     String,
                     Vec<f32>,
                     Vec<f32>,
+                    f32,
                 )| {
                     Ok(LuaVehicleData(VehicleData {
                         parts_config,
@@ -448,6 +449,7 @@ pub fn setup_lua() -> (rlua::Lua, mpsc::Receiver<LuaCommand>) {
                         owner: None,
                         position: [position[0], position[1], position[2]],
                         rotation: [rotation[0], rotation[1], rotation[2], rotation[3]],
+                        slowmo_factor: slowmo_factor,
                     }))
                 },
             )

--- a/shared/src/vehicle/mod.rs
+++ b/shared/src/vehicle/mod.rs
@@ -30,6 +30,7 @@ pub struct VehicleData {
     pub owner: Option<u32>,
     pub position: [f32; 3],
     pub rotation: [f32; 4],
+    pub slowmo_factor: f32,
 }
 
 // A single packet that contains all of the vehicle updates.

--- a/shared/src/vehicle/vehicle_meta.rs
+++ b/shared/src/vehicle/vehicle_meta.rs
@@ -5,4 +5,5 @@ pub struct VehicleMeta {
     pub vehicle_id: u32,
     pub plate: Option<String>,
     pub colors_table: [[f32; 8]; 3],
+    pub slowmo_factor: f32,
 }


### PR DESCRIPTION
This implements vehicles no longer rubberbanding when paused, instead stopping them, disabling collision, and reducing opacity.
Might need additional bounding box check to avoid intense clipping when unpausing while a different car is inside the paused one.